### PR TITLE
Lint fixes

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -84,7 +84,7 @@ func newPinDialer(s StorageReader, r PinFailureReporter, pinOnly bool, defaultTL
 			return c, nil
 		}
 
-		// do a normal dial, address isnt in hpkp cache
+		// do a normal dial, address isn't in hpkp cache
 		return tls.Dial(network, addr, defaultTLSConfig)
 	}
 }

--- a/header.go
+++ b/header.go
@@ -14,7 +14,7 @@ type Header struct {
 	IncludeSubDomains bool
 	Permanent         bool
 	Sha256Pins        []string
-	ReportUri         string
+	ReportURI         string
 }
 
 // Matches checks whether the provided pin is in the header list
@@ -83,7 +83,7 @@ func populate(h *Header, v string) *Header {
 
 		i = strings.Index(field, "report-uri")
 		if i >= 0 {
-			h.ReportUri = field[i+12 : len(field)-1]
+			h.ReportURI = field[i+12 : len(field)-1]
 			continue
 		}
 

--- a/header.go
+++ b/header.go
@@ -47,7 +47,7 @@ func ParseHeader(resp *http.Response) *Header {
 	return populate(&Header{}, v[0])
 }
 
-// ParseReportOnlyHeader parses the hpkp information from an http.Reponse.
+// ParseReportOnlyHeader parses the hpkp information from an http.Response.
 // The resulting header information should not be cached as max_age is
 // ignored on HPKP-RO headers per the RFC.
 func ParseReportOnlyHeader(resp *http.Response) *Header {

--- a/header_test.go
+++ b/header_test.go
@@ -148,7 +148,7 @@ func TestParseHeader(t *testing.T) {
 					"E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=",
 					"LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=",
 				},
-				ReportUri: "http://example.com/pkp-report",
+				ReportURI: "http://example.com/pkp-report",
 			},
 		},
 		{
@@ -292,7 +292,7 @@ func TestParseReportOnlyHeader(t *testing.T) {
 					"E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=",
 					"LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=",
 				},
-				ReportUri: "http://example.com/pkp-report",
+				ReportURI: "http://example.com/pkp-report",
 			},
 		},
 	}
@@ -328,7 +328,7 @@ func equalHeaders(a, b *Header) bool {
 		return false
 	}
 
-	if a.ReportUri != b.ReportUri {
+	if a.ReportURI != b.ReportURI {
 		return false
 	}
 

--- a/report.go
+++ b/report.go
@@ -43,7 +43,7 @@ func NewPinFailure(host string, port int, h *Header, c tls.ConnectionState) (*Pi
 		ServedCertificateChain:    encodeCertificatesPEM(c.PeerCertificates),
 		ValidatedCertificateChain: encodeCertificatesPEM(verifiedChain),
 		KnownPins:                 h.Sha256Pins,
-	}, h.ReportUri
+	}, h.ReportURI
 }
 
 // encodeCertificatesPEM converts a slice of x509 certficates to a slice of PEM encoded strings

--- a/report_test.go
+++ b/report_test.go
@@ -131,7 +131,7 @@ func TestNewPinFailure(t *testing.T) {
 		header         *Header
 		connState      tls.ConnectionState
 		expectedReport *PinFailure
-		expectedUri    string
+		expectedURI    string
 	}{
 		{
 			name: "nil test",
@@ -164,15 +164,15 @@ func TestNewPinFailure(t *testing.T) {
 				ServedCertificateChain:    certs[:1],
 				ValidatedCertificateChain: certs,
 			},
-			expectedUri: "",
+			expectedURI: "",
 		},
 	}
 
 	for _, test := range tests {
 		pf, uri := NewPinFailure(test.host, test.port, test.header, test.connState)
 
-		if uri != test.expectedUri {
-			t.Logf("want:%v", test.expectedUri)
+		if uri != test.expectedURI {
+			t.Logf("want:%v", test.expectedURI)
 			t.Logf("got:%v", uri)
 			t.Fatalf("test case failed: %s", test.name)
 		}


### PR DESCRIPTION
`ReportUri` -> `ReportURI` would be a breaking change
